### PR TITLE
Fixed panic in deprecated attachment functions (#39)

### DIFF
--- a/attach_old.go
+++ b/attach_old.go
@@ -17,8 +17,12 @@ func (email *Email) AddAttachment(file string, name ...string) *Email {
 		email.Error = errors.New("Mail Error: Attach can only have a file and an optional name")
 		return email
 	}
-
-	return email.Attach(&File{Name: name[0], FilePath: file})
+	
+	var nm string
+	if len(name) == 1 {
+		nm = name[0]
+	}
+	return email.Attach(&File{Name: nm, FilePath: file})
 }
 
 // AddAttachmentData. DEPRECATED. Use Attach method. Allows you to add an in-memory attachment to the email message.
@@ -43,8 +47,13 @@ func (email *Email) AddInline(file string, name ...string) *Email {
 		email.Error = errors.New("Mail Error: Inline can only have a file and an optional name")
 		return email
 	}
-
-	return email.Attach(&File{Name: name[0], FilePath: file, Inline: true})
+	
+	var nm string
+	if len(name) == 1 {
+		nm = name[0]
+	}
+	
+	return email.Attach(&File{Name: nm, FilePath: file, Inline: true})
 }
 
 // AddInlineData. DEPRECATED. Use Attach method. Allows you to add an inline in-memory attachment to the email message.

--- a/attach_test.go
+++ b/attach_test.go
@@ -105,4 +105,18 @@ func TestAttachments(t *testing.T) {
 		got := msg.attachments[0].Data
 		checkByteSlice(t, got, want)
 	})
+	t.Run("Inline File not name Deprecated", func(t *testing.T) {
+		msg := NewMSG()
+		msg.AddInline("testdata/foo.txt")
+		checkError(t, msg.Error)
+		got := msg.inlines[0].Data
+		checkByteSlice(t, got, want)
+	})
+	t.Run("Attachment File not name Deprecated", func(t *testing.T) {
+		msg := NewMSG()
+		msg.AddAttachment("testdata/foo.txt")
+		checkError(t, msg.Error)
+		got := msg.attachments[0].Data
+		checkByteSlice(t, got, want)
+	})
 }


### PR DESCRIPTION
* Fixed panic in deprecated attachment functions

Fixed panic when AddAttachment and AddInline functions are called without name of file.

* Add test for attachment without name